### PR TITLE
Update Readme Gemfile installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Inspired by [Stripe's prefixed IDs](https://stripe.com/docs/api) in their API.
 Add this line to your application's Gemfile:
 
 ```ruby
-bundle add 'prefixed_ids'
+gem 'prefixed_ids'
 ```
 
 ## 📝 Usage


### PR DESCRIPTION
The Installation instructions in the readme implied that one should literally type a "bundle add" command into the gemfile.  I replaced the bundle add command with typical gemfile text for this gem, without any version locking.