### PR TITLE
Change before_create to before_save

### DIFF
--- a/lib/prefixed_ids.rb
+++ b/lib/prefixed_ids.rb
@@ -16,7 +16,7 @@ module PrefixedIds
         # Load securerandom only when has_secure_token is used.
         require "active_support/core_ext/securerandom"
         define_method("regenerate_#{attribute}") { update! attribute => self.class.generate_unique_prefix_id(prefix, length: length) }
-        before_create { send("#{attribute}=", self.class.generate_unique_prefix_id(prefix, length: length)) unless send("#{attribute}?") }
+        before_save { send("#{attribute}=", self.class.generate_unique_prefix_id(prefix, length: length)) unless send("#{attribute}?") }
       end
 
       def generate_unique_prefix_id(prefix, length: MINIMUM_TOKEN_LENGTH)


### PR DESCRIPTION
I propose changing before_create to before_save; this makes sure that, for instance, if you need to "reset" this ID for whatever reason, a simple `user.update(prefix_id: nil)` is all it takes to make it be re-generated.