### PR TITLE
Fix custom alphabet not being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* [ADD] Add `PrefixedIds.delimiter` to be able to change the default delimiter - @rbague
 * [FIX] Custom alphabet was not being used to generate the prefixed_id - @rbague
 
 ### 1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* [FIX] Custom alphabet was not being used to generate the prefixed_id - @rbague
+
 ### 1.2.0
 
 * Add `PrefixedIds.find` to lookup any model by prefixed ID

--- a/lib/prefixed_ids.rb
+++ b/lib/prefixed_ids.rb
@@ -8,7 +8,6 @@ module PrefixedIds
 
   autoload :PrefixId, "prefixed_ids/prefix_id"
 
-  TOKEN = 123
   DELIMITER = "_"
 
   mattr_accessor :alphabet, default: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"

--- a/lib/prefixed_ids.rb
+++ b/lib/prefixed_ids.rb
@@ -8,8 +8,7 @@ module PrefixedIds
 
   autoload :PrefixId, "prefixed_ids/prefix_id"
 
-  DELIMITER = "_"
-
+  mattr_accessor :delimiter, default: "_"
   mattr_accessor :alphabet, default: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
   mattr_accessor :minimum_length, default: 24
 
@@ -23,8 +22,8 @@ module PrefixedIds
   end
 
   # Splits a prefixed ID into its prefix and ID
-  def self.split_id(prefix_id)
-    prefix, _, id = prefix_id.to_s.rpartition(DELIMITER)
+  def self.split_id(prefix_id, delimiter = PrefixedIds.delimiter)
+    prefix, _, id = prefix_id.to_s.rpartition(delimiter)
     [prefix, id]
   end
 

--- a/lib/prefixed_ids/prefix_id.rb
+++ b/lib/prefixed_ids/prefix_id.rb
@@ -1,16 +1,16 @@
 module PrefixedIds
   class PrefixId
-    attr_reader :hashids, :model, :prefix
+    attr_reader :hashids, :prefix
+
+    TOKEN = 123
 
     def initialize(model, prefix, minimum_length: PrefixedIds.minimum_length, alphabet: PrefixedIds.alphabet, **options)
-      @alphabet = alphabet
-      @model = model
       @prefix = prefix.to_s
-      @hashids = Hashids.new(model.table_name, minimum_length)
+      @hashids = Hashids.new(model.table_name, minimum_length, alphabet)
     end
 
     def encode(id)
-      prefix + "_" + @hashids.encode(TOKEN, id)
+      prefix + PrefixedIds::DELIMITER + @hashids.encode(TOKEN, id)
     end
 
     # decode returns an array

--- a/lib/prefixed_ids/prefix_id.rb
+++ b/lib/prefixed_ids/prefix_id.rb
@@ -4,19 +4,20 @@ module PrefixedIds
 
     TOKEN = 123
 
-    def initialize(model, prefix, minimum_length: PrefixedIds.minimum_length, alphabet: PrefixedIds.alphabet, **options)
+    def initialize(model, prefix, minimum_length: PrefixedIds.minimum_length, alphabet: PrefixedIds.alphabet, delimiter: PrefixedIds.delimiter, **options)
       @prefix = prefix.to_s
+      @delimiter = delimiter.to_s
       @hashids = Hashids.new(model.table_name, minimum_length, alphabet)
     end
 
     def encode(id)
-      prefix + PrefixedIds::DELIMITER + @hashids.encode(TOKEN, id)
+      @prefix + @delimiter + @hashids.encode(TOKEN, id)
     end
 
     # decode returns an array
     def decode(id, fallback: false)
       fallback_value = fallback ? id : nil
-      _, id_without_prefix = PrefixedIds.split_id(id)
+      _, id_without_prefix = PrefixedIds.split_id(id, @delimiter)
       decoded_id = @hashids.decode(id_without_prefix).last
       decoded_id || fallback_value
     end

--- a/lib/prefixed_ids/prefix_id.rb
+++ b/lib/prefixed_ids/prefix_id.rb
@@ -18,8 +18,16 @@ module PrefixedIds
     def decode(id, fallback: false)
       fallback_value = fallback ? id : nil
       _, id_without_prefix = PrefixedIds.split_id(id, @delimiter)
-      decoded_id = @hashids.decode(id_without_prefix).last
-      decoded_id || fallback_value
+      decoded_hashid = @hashids.decode(id_without_prefix)
+      return fallback_value unless valid?(decoded_hashid)
+
+      decoded_hashid.last || fallback_value
+    end
+
+    private
+
+    def valid?(decoded_hashid)
+      decoded_hashid.size == 2 && decoded_hashid.first == TOKEN
     end
   end
 end

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -79,4 +79,10 @@ class PrefixedIdsTest < ActiveSupport::TestCase
     assert_not_equal default, custom
     assert_equal default_encoder.decode(default), custom_encoder.decode(custom)
   end
+
+  test "can change the default delimiter delimiter" do
+    slash = PrefixedIds::PrefixId.new(User, "user", delimiter: "/")
+
+    assert slash.encode(1).start_with?("user/")
+  end
 end

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -85,4 +85,19 @@ class PrefixedIdsTest < ActiveSupport::TestCase
 
     assert slash.encode(1).start_with?("user/")
   end
+
+  test "checks for a valid id upon decoding" do
+    prefix = PrefixedIds::PrefixId.new(User, "user")
+    hashid = Hashids.new(User.table_name, PrefixedIds.minimum_length, PrefixedIds.alphabet)
+
+    first = prefix.encode(1)
+    second = hashid.encode(1)
+
+    assert_not_equal first.delete_prefix("user" + PrefixedIds.delimiter), second
+    assert_equal prefix.decode(second, fallback: true), second
+
+    decoded = hashid.decode(second)
+    assert_equal decoded.size, 1
+    assert_equal decoded.first, 1
+  end
 end

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -68,4 +68,15 @@ class PrefixedIdsTest < ActiveSupport::TestCase
   test "split_id" do
     assert_equal ["user", "1234"], PrefixedIds.split_id("user_1234")
   end
+
+  test "can use a custom alphabet" do
+    default_encoder = PrefixedIds::PrefixId.new(User, "user", alphabet: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
+    custom_encoder = PrefixedIds::PrefixId.new(User, "user", alphabet: "5N6y2rljDQak4xgzn8ZR1oKYLmJpEbVq3OBv9WwXPMe7")
+
+    default = default_encoder.encode(1)
+    custom = custom_encoder.encode(1)
+
+    assert_not_equal default, custom
+    assert_equal default_encoder.decode(default), custom_encoder.decode(custom)
+  end
 end


### PR DESCRIPTION
The current implementation does not take into account if the user had specified an alternative alphabet in the configuration, thus always generating the prefixed_id with the default alphabet.
I've also updated the encode method to use the delimiter constant in [PrefixedIds](https://github.com/excid3/prefixed_ids/blob/ad7e5869cf5a0f4842e58b954fcd8c55112eea8e/lib/prefixed_ids.rb#L12), just in case in the future you want to make it configurable.