### PR TITLE
Customizable salt

### DIFF
--- a/lib/prefixed_ids.rb
+++ b/lib/prefixed_ids.rb
@@ -11,6 +11,7 @@ module PrefixedIds
   mattr_accessor :delimiter, default: "_"
   mattr_accessor :alphabet, default: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
   mattr_accessor :minimum_length, default: 24
+  mattr_accessor :salt, default: ""
 
   mattr_accessor :models, default: {}
 

--- a/lib/prefixed_ids/prefix_id.rb
+++ b/lib/prefixed_ids/prefix_id.rb
@@ -4,10 +4,10 @@ module PrefixedIds
 
     TOKEN = 123
 
-    def initialize(model, prefix, minimum_length: PrefixedIds.minimum_length, alphabet: PrefixedIds.alphabet, delimiter: PrefixedIds.delimiter, **options)
+    def initialize(model, prefix, salt: PrefixedIds.salt, minimum_length: PrefixedIds.minimum_length, alphabet: PrefixedIds.alphabet, delimiter: PrefixedIds.delimiter, **options)
       @prefix = prefix.to_s
       @delimiter = delimiter.to_s
-      @hashids = Hashids.new(model.table_name, minimum_length, alphabet)
+      @hashids = Hashids.new("#{model.table_name}#{salt}", minimum_length, alphabet)
     end
 
     def encode(id)

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -84,7 +84,7 @@ class PrefixedIdsTest < ActiveSupport::TestCase
     assert_equal default_encoder.decode(default), custom_encoder.decode(custom)
   end
 
-  test "can change the default delimiter delimiter" do
+  test "can change the default delimiter" do
     slash = PrefixedIds::PrefixId.new(User, "user", delimiter: "/")
 
     assert slash.encode(1).start_with?("user/")

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -13,6 +13,10 @@ class PrefixedIdsTest < ActiveSupport::TestCase
     assert_equal 24, PrefixedIds.minimum_length
   end
 
+  test "default salt" do
+    assert_equal "", PrefixedIds.salt
+  end
+
   test "has a prefix ID" do
     prefix_id = users(:one).prefix_id
     assert_not_nil prefix_id
@@ -84,6 +88,17 @@ class PrefixedIdsTest < ActiveSupport::TestCase
     slash = PrefixedIds::PrefixId.new(User, "user", delimiter: "/")
 
     assert slash.encode(1).start_with?("user/")
+  end
+
+  test "can use a custom salt" do
+    default_encoder = PrefixedIds::PrefixId.new(User, "user")
+    custom_encoder = PrefixedIds::PrefixId.new(User, "user", salt: "truffle")
+
+    default = default_encoder.encode(1)
+    custom = custom_encoder.encode(1)
+
+    assert_not_equal default, custom
+    assert_equal default_encoder.decode(default), custom_encoder.decode(custom)
   end
 
   test "checks for a valid id upon decoding" do


### PR DESCRIPTION
Nice library! And I was just about to add hashids to my project when I saw @drnic's tweet about this 💥

This PR adds a `salt` option to `PrefixedIds::PrefixId`, making it customizable.

I _think_ this could be globally configurable in an initializer like so:

```rb
PrefixedIds.salt = Rails.application.credentials.secret_key_base
```

Although I'm wondering if there might be a more Rails-y API for this? (I'm not too familiar with contributing to gems, so would be interested to see/hear how you might approach this :)

If I'm heading in the right direction with this PR, let me know and I'll add documentation.

Fixes #6