### PR TITLE
Add `decode_prefix_id` class method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Add `decode_prefix_id` and `decode_prefix_ids` class methods - @TastyPi
+
 ### 1.3.0
 
 * Add `PrefixedIds.salt` and `has_prefix_id salt: ""` option - @domchristie

--- a/lib/prefixed_ids.rb
+++ b/lib/prefixed_ids.rb
@@ -62,7 +62,7 @@ module PrefixedIds
         find_by!(id: _prefix_id.decode(id))
       end
 
-      def unprefix_id(id)
+      def decode_prefix_id(id)
         _prefix_id.decode(id)
       end
     end

--- a/lib/prefixed_ids.rb
+++ b/lib/prefixed_ids.rb
@@ -61,6 +61,10 @@ module PrefixedIds
       def find_by_prefix_id!(id)
         find_by!(id: _prefix_id.decode(id))
       end
+
+      def unprefix_id(id)
+        _prefix_id.decode(id)
+      end
     end
 
     def prefix_id

--- a/lib/prefixed_ids.rb
+++ b/lib/prefixed_ids.rb
@@ -65,6 +65,10 @@ module PrefixedIds
       def decode_prefix_id(id)
         _prefix_id.decode(id)
       end
+
+      def decode_prefix_ids(ids)
+        ids.map { |id| decode_prefix_id(id) }
+      end
     end
 
     def prefix_id

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -17,6 +17,10 @@ class PrefixedIdsTest < ActiveSupport::TestCase
     assert_equal "", PrefixedIds.salt
   end
 
+  test "can get original ID from prefix ID" do
+    assert_equal users(:one).id, User.unprefix_id(users(:one).prefix_id)
+  end
+
   test "has a prefix ID" do
     prefix_id = users(:one).prefix_id
     assert_not_nil prefix_id

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -18,7 +18,7 @@ class PrefixedIdsTest < ActiveSupport::TestCase
   end
 
   test "can get original ID from prefix ID" do
-    assert_equal users(:one).id, User.unprefix_id(users(:one).prefix_id)
+    assert_equal users(:one).id, User.decode_prefix_id(users(:one).prefix_id)
   end
 
   test "has a prefix ID" do

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -21,6 +21,13 @@ class PrefixedIdsTest < ActiveSupport::TestCase
     assert_equal users(:one).id, User.decode_prefix_id(users(:one).prefix_id)
   end
 
+  test "can get original IDs from multiple prefix IDs" do
+    assert_equal(
+      [users(:one).id, users(:two).id, users(:three).id],
+      User.decode_prefix_ids([users(:one).prefix_id, users(:two).prefix_id, users(:three).prefix_id])
+    )
+  end
+
   test "has a prefix ID" do
     prefix_id = users(:one).prefix_id
     assert_not_nil prefix_id


### PR DESCRIPTION
It's useful to be able to convert a prefix ID to a standard ID. For example, I want to be able to do something like this in a single SQL query:

```ruby
class Foo < ActiveRecord::Base
  has_prefix_id :foo
  has_one :bar
end

class Bar < ActiveRecord::Base
  has_prefix_id :bar
  belongs_to :foo
end

foo_prefix_ids = # Get list of prefix IDs from external system

# List the Bars that do not belong to any of the Foos
bars = Bar.where.not(foo_id: foo_prefix_ids.map { |id| Foo.unprefix_id(id) })
```