### PR TITLE
Fixes "undefined method `decode' for nil:NilClass"

### DIFF
--- a/lib/prefixed_ids.rb
+++ b/lib/prefixed_ids.rb
@@ -84,9 +84,13 @@ module PrefixedIds
     class_methods do
       def find(*ids)
         prefix_ids = *ids.map do |id|
-          prefix_id = _prefix_id.decode(id, fallback: _prefix_id_fallback)
-          raise Error, "#{id} is not a valid prefix_id" if !_prefix_id_fallback && prefix_id.nil?
-          prefix_id
+          if _prefix_id
+            prefix_id = _prefix_id.decode(id, fallback: _prefix_id_fallback)
+            raise Error, "#{id} is not a valid prefix_id" if !_prefix_id_fallback && prefix_id.nil?
+            prefix_id
+          else
+            id
+          end
         end
         super(*prefix_ids)
       end

--- a/lib/prefixed_ids/version.rb
+++ b/lib/prefixed_ids/version.rb
@@ -1,3 +1,3 @@
 module PrefixedIds
-  VERSION = "1.5.0"
+  VERSION = "1.5.1"
 end

--- a/test/dummy/app/models/no_prefix_id_item.rb
+++ b/test/dummy/app/models/no_prefix_id_item.rb
@@ -1,0 +1,3 @@
+class NoPrefixIdItem < ApplicationRecord
+  belongs_to :user
+end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -2,4 +2,5 @@ class User < ApplicationRecord
   has_prefix_id :user
   has_many :accounts
   has_many :posts
+  has_many :no_prefix_id_items
 end

--- a/test/dummy/db/migrate/20230503211115_create_no_prefix_id_items.rb
+++ b/test/dummy/db/migrate/20230503211115_create_no_prefix_id_items.rb
@@ -1,0 +1,9 @@
+class CreateNoPrefixIdItems < ActiveRecord::Migration[6.1]
+  def change
+    create_table :no_prefix_id_items do |t|
+      t.integer :user_id
+      t.timestamps
+    end
+  end
+end
+

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,8 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_22_131821) do
+ActiveRecord::Schema.define(version: 2023_05_03_211115) do
   create_table "accounts", force: :cascade do |t|
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "no_prefix_id_items", force: :cascade do |t|
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/test/fixtures/no_prefix_id_items.yml
+++ b/test/fixtures/no_prefix_id_items.yml
@@ -1,0 +1,14 @@
+one:
+  user: one
+
+two:
+  user: two
+
+three:
+  user: three
+
+four:
+  user: one
+
+five:
+  user: one

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -163,4 +163,12 @@ class PrefixedIdsTest < ActiveSupport::TestCase
       Team.find(ActiveRecord::FixtureSet.identify(:one))
     end
   end
+
+  test "calling find on an associated model without prefix id succeeds" do
+    no_prefix_id_item = no_prefix_id_items(:one)
+    user = users(:one)
+
+    assert_equal user.no_prefix_id_items.find(no_prefix_id_item.id), no_prefix_id_item
+    assert_raises(ActiveRecord::RecordNotFound) { user.no_prefix_id_items.find(9999999) }
+  end
 end


### PR DESCRIPTION
Fixes an exception that occurs when you invoke find on a non prefixed id association of a prefixed_id model.

For example, if the User model has prefix ids and it has an association no_prefix_id_items to a model called NoPrefixIdItem, then the following would fail: user.no_prefix_id_items.find(22).

The tests I have added should illustrate this edgecase more specifically. 