### PR TITLE
Add `prefix_id` class methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Add `prefix_id` and `prefix_ids` class methods - @TastyPi
+
 ### 1.5.1
 
 * [FIX] Fixes an exception that occurs when you invoke find on a non prefixed association of a prefixed_id model. #49 - @MishaConway

--- a/lib/prefixed_ids.rb
+++ b/lib/prefixed_ids.rb
@@ -64,6 +64,14 @@ module PrefixedIds
         find_by!(id: _prefix_id.decode(id))
       end
 
+      def prefix_id(id)
+        _prefix_id.encode(id)
+      end
+
+      def prefix_ids(ids)
+        ids.map { |id| prefix_id(id) }
+      end
+
       def decode_prefix_id(id)
         _prefix_id.decode(id)
       end

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -17,6 +17,17 @@ class PrefixedIdsTest < ActiveSupport::TestCase
     assert_equal "", PrefixedIds.salt
   end
 
+  test "can get prefix ID from original ID" do
+    assert_equal users(:one).prefix_id, User.prefix_id(users(:one).id)
+  end
+
+  test "can get prefix IDs from multiple original IDs" do
+    assert_equal(
+      [users(:one).prefix_id, users(:two).prefix_id, users(:three).prefix_id],
+      User.prefix_ids([users(:one).id, users(:two).id, users(:three).id])
+    )
+  end
+
   test "can get original ID from prefix ID" do
     assert_equal users(:one).id, User.decode_prefix_id(users(:one).prefix_id)
   end


### PR DESCRIPTION
This is essentially the reverse of https://github.com/excid3/prefixed_ids/pull/45.

A use case for this is `belongs_to` associations, instead of doing `assoc.prefix_id` you can do `Model.prefix_id(assoc_id)` to avoid an unnecessary database lookup.