### PR TITLE
Fix behaviour when array of ids is passed to find

### DIFF
--- a/lib/prefixed_ids.rb
+++ b/lib/prefixed_ids.rb
@@ -91,7 +91,7 @@ module PrefixedIds
 
     class_methods do
       def find(*ids)
-        prefix_ids = *ids.map do |id|
+        prefix_ids = *ids.flatten.map do |id|
           # Skip if model doesn't use prefixed ids
           next id unless _prefix_id.present?
 
@@ -99,6 +99,7 @@ module PrefixedIds
           raise Error, "#{id} is not a valid prefix_id" if !_prefix_id_fallback && prefix_id.nil?
           prefix_id
         end
+        prefix_ids = [prefix_ids] if ids.first.is_a?(Array)
         super(*prefix_ids)
       end
 

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -65,6 +65,17 @@ class PrefixedIdsTest < ActiveSupport::TestCase
     assert_equal [user, user2], User.find(user.prefix_id, user2.prefix_id)
   end
 
+  test "overridden finders with array args" do
+    user = users(:one)
+    user2 = users(:two)
+    assert_equal [user, user2], User.find([user.prefix_id, user2.prefix_id])
+  end
+
+  test "overridden finders with single array args" do
+    user = users(:one)
+    assert_equal [user], User.find([user.prefix_id])
+  end
+
   test "minimum length" do
     assert_equal 32 + 5, accounts(:one).prefix_id.length
   end


### PR DESCRIPTION
The original rails find allows an array of ids to be passed to the find method. However, the find method in prefix_ids doesn't. This change makes the find method compliant with what the default rails method does.