### PR TITLE
Add option to check record existence when object is prefixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,26 @@ PrefixedIds.find("acct_2iAnOP0xGDYk6dpe")
 #=> #<Account>
 ```
 
+### Exists
+
+You can check if a record exists by its prefixed ID:
+
+```ruby
+User.exists?("user_5vJjbzXq9KrLEMm3")
+#=> true
+```
+
+If given anything other than a prefixed ID, or `override_exists` is set to false, it will fall back to its original `exists?` method.
+
+```ruby
+class User < ApplicationRecord
+  has_prefix_id :user, override_exists: false
+end
+
+User.exists?("user_5vJjbzXq9KrLEMm3")
+#=> false
+```
+
 ### Customizing Prefix IDs
 
 You can customize the prefix, length, and attribute name for PrefixedIds.

--- a/lib/prefixed_ids.rb
+++ b/lib/prefixed_ids.rb
@@ -130,15 +130,10 @@ module PrefixedIds
 
     class_methods do
       def exists?(id)
-        return super(id) unless _prefix_id.present?
-
-        # `exists?` also accept conditions (e.g. `exists?(id: 1)`). These include, for example, Hashes and Arrays.
-        # In these cases, we know it can't be a prefixed ID so we just delegate to the original method.
-        return super(id) unless id.is_a?(String)
-
-        prefixed_id = _prefix_id.decode(id)
-
-        super(prefixed_id)
+        if _prefix_id.present? && id.is_a?(String)
+          super(_prefix_id.decode(id))
+        else
+          super(id)
       end
     end
   end

--- a/lib/prefixed_ids.rb
+++ b/lib/prefixed_ids.rb
@@ -133,7 +133,7 @@ module PrefixedIds
         if _prefix_id.present? && id.is_a?(String)
           super(_prefix_id.decode(id))
         else
-          super(id)
+          super
         end
       end
     end

--- a/lib/prefixed_ids.rb
+++ b/lib/prefixed_ids.rb
@@ -134,6 +134,7 @@ module PrefixedIds
           super(_prefix_id.decode(id))
         else
           super(id)
+        end
       end
     end
   end

--- a/test/dummy/app/models/post.rb
+++ b/test/dummy/app/models/post.rb
@@ -1,4 +1,4 @@
 class Post < ApplicationRecord
-  has_prefix_id :post
+  has_prefix_id :post, override_exists: false
   belongs_to :user
 end

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -191,6 +191,23 @@ class PrefixedIdsTest < ActiveSupport::TestCase
     assert_equal account, account.user.accounts.find(account.prefix_id)
   end
 
+  test "exists? works with prefixed ID" do
+    account = accounts(:one)
+    assert Account.exists?(account.prefix_id)
+  end
+
+  test "disabled exists? with prefixed ID" do
+    post = posts(:one)
+
+    refute Post.exists?(post.prefix_id)
+  end
+
+  test "exists? works with conditions instead of ID" do
+    account = accounts(:one)
+
+    assert Account.exists?(id: account.id)
+  end
+
   test "calling find on an associated model without prefix id succeeds" do
     nonprefixed_item = nonprefixed_items(:one)
     user = users(:one)


### PR DESCRIPTION
hey 👋🏻 

I've been checking for record existences on my app and noticed it has become a two-line operation, where I first have to decode the ID and then call `exists?`. I figure I could try improve that.