### PR TITLE
fix: `to_param` for non-persisted records

### DIFF
--- a/lib/prefixed_ids/prefix_id.rb
+++ b/lib/prefixed_ids/prefix_id.rb
@@ -11,6 +11,8 @@ module PrefixedIds
     end
 
     def encode(id)
+      return if id.nil?
+      
       @prefix + @delimiter + @hashids.encode(TOKEN, id)
     end
 

--- a/lib/prefixed_ids/prefix_id.rb
+++ b/lib/prefixed_ids/prefix_id.rb
@@ -12,7 +12,7 @@ module PrefixedIds
 
     def encode(id)
       return if id.nil?
-      
+
       @prefix + @delimiter + @hashids.encode(TOKEN, id)
     end
 

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -215,4 +215,8 @@ class PrefixedIdsTest < ActiveSupport::TestCase
     assert_equal user.nonprefixed_items.find(nonprefixed_item.id), nonprefixed_item
     assert_raises(ActiveRecord::RecordNotFound) { user.nonprefixed_items.find(9999999) }
   end
+
+  test "calling to_param on non-persisted record" do
+    assert_nil Post.new.to_param
+  end
 end


### PR DESCRIPTION
Fix a bug where calling `to_param` would raise ```<internal:kernel>:307:in `Integer': can't convert nil into Integer (TypeError)``` for non-persisted records.