### PR TITLE
Support compound primary keys, as introduced in Rails 7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Add composite key support #70
+
 ### 1.7.1
 
 * Safely handle `to_param` for new records #69

--- a/lib/prefixed_ids/prefix_id.rb
+++ b/lib/prefixed_ids/prefix_id.rb
@@ -27,8 +27,9 @@ module PrefixedIds
       if fallback && !valid?(decoded_hashid)
         fallback_value
       else
-        token = decoded_hashid.shift
-        decoded_hashid
+        _ = decoded_hashid.shift
+
+        decoded_hashid = decoded_hashid.first if decoded_hashid.size == 1
       end
     end
 

--- a/lib/prefixed_ids/prefix_id.rb
+++ b/lib/prefixed_ids/prefix_id.rb
@@ -13,9 +13,7 @@ module PrefixedIds
     def encode(id)
       return if id.nil?
 
-      args = [TOKEN]
-      args += id.is_a?(Array) ? id : [id]
-
+      args = [TOKEN] + Array.wrap(id)
       @prefix + @delimiter + @hashids.encode(args)
     end
 

--- a/lib/prefixed_ids/prefix_id.rb
+++ b/lib/prefixed_ids/prefix_id.rb
@@ -14,7 +14,7 @@ module PrefixedIds
       return if id.nil?
 
       args = [TOKEN]
-      args += id.kind_of?(Array) ? id : [id]
+      args += id.is_a?(Array) ? id : [id]
 
       @prefix + @delimiter + @hashids.encode(args)
     end

--- a/lib/prefixed_ids/prefix_id.rb
+++ b/lib/prefixed_ids/prefix_id.rb
@@ -13,7 +13,10 @@ module PrefixedIds
     def encode(id)
       return if id.nil?
 
-      @prefix + @delimiter + @hashids.encode(TOKEN, id)
+      args = [TOKEN]
+      args += id.kind_of?(Array) ? id : [id]
+
+      @prefix + @delimiter + @hashids.encode(args)
     end
 
     # decode returns an array
@@ -24,14 +27,15 @@ module PrefixedIds
       if fallback && !valid?(decoded_hashid)
         fallback_value
       else
-        decoded_hashid.last
+        token = decoded_hashid.shift
+        decoded_hashid
       end
     end
 
     private
 
     def valid?(decoded_hashid)
-      decoded_hashid.size == 2 && decoded_hashid.first == TOKEN
+      decoded_hashid.size >= 2 && decoded_hashid.first == TOKEN
     end
   end
 end

--- a/lib/prefixed_ids/prefix_id.rb
+++ b/lib/prefixed_ids/prefix_id.rb
@@ -22,12 +22,19 @@ module PrefixedIds
       fallback_value = fallback ? id : nil
       _, id_without_prefix = PrefixedIds.split_id(id, @delimiter)
       decoded_hashid = @hashids.decode(id_without_prefix)
+
       if fallback && !valid?(decoded_hashid)
         fallback_value
+      elsif !valid?(decoded_hashid)
+        nil
       else
         _ = decoded_hashid.shift
 
-        decoded_hashid = decoded_hashid.first if decoded_hashid.size == 1
+        if decoded_hashid.size == 1
+          decoded_hashid.first
+        else
+          decoded_hashid
+        end
       end
     end
 

--- a/lib/prefixed_ids/prefix_id.rb
+++ b/lib/prefixed_ids/prefix_id.rb
@@ -22,10 +22,8 @@ module PrefixedIds
       _, id_without_prefix = PrefixedIds.split_id(id, @delimiter)
       decoded_hashid = @hashids.decode(id_without_prefix)
 
-      if fallback && !valid?(decoded_hashid)
+      if !valid?(decoded_hashid)
         fallback_value
-      elsif !valid?(decoded_hashid)
-        nil
       else
         _, id, *composite = decoded_hashid
         composite.empty? ? id : composite

--- a/lib/prefixed_ids/prefix_id.rb
+++ b/lib/prefixed_ids/prefix_id.rb
@@ -13,8 +13,7 @@ module PrefixedIds
     def encode(id)
       return if id.nil?
 
-      args = [TOKEN] + Array.wrap(id)
-      @prefix + @delimiter + @hashids.encode(args)
+      @prefix + @delimiter + @hashids.encode([TOKEN] + Array.wrap(id))
     end
 
     # decode returns an array

--- a/lib/prefixed_ids/prefix_id.rb
+++ b/lib/prefixed_ids/prefix_id.rb
@@ -27,13 +27,8 @@ module PrefixedIds
       elsif !valid?(decoded_hashid)
         nil
       else
-        _ = decoded_hashid.shift
-
-        if decoded_hashid.size == 1
-          decoded_hashid.first
-        else
-          decoded_hashid
-        end
+        _, id, *composite = decoded_hashid
+        composite.empty? ? id : composite
       end
     end
 

--- a/test/dummy/app/models/compound_primary_item.rb
+++ b/test/dummy/app/models/compound_primary_item.rb
@@ -1,0 +1,7 @@
+class CompoundPrimaryItem < ApplicationRecord
+  self.primary_key = [ :id, :user_id ]
+
+  has_prefix_id :compound, minimum_length: 32, override_find: false, override_param: false, salt: "abcd"
+
+  belongs_to :user
+end

--- a/test/dummy/app/models/compound_primary_item.rb
+++ b/test/dummy/app/models/compound_primary_item.rb
@@ -1,5 +1,5 @@
 class CompoundPrimaryItem < ApplicationRecord
-  self.primary_key = [ :id, :user_id ]
+  self.primary_key = [:id, :user_id]
 
   has_prefix_id :compound, minimum_length: 32, override_find: false, override_param: false, salt: "abcd"
 

--- a/test/dummy/config/initializers/prefixed_ids_test.rb
+++ b/test/dummy/config/initializers/prefixed_ids_test.rb
@@ -1,0 +1,19 @@
+# Largely copied from https://github.com/heartcombo/devise/blob/main/test/rails_app/config/boot.rb
+
+module PrefixedIds
+  module Test
+    # Detection for minor differences between Rails versions in tests.
+
+    def self.rails71_and_up?
+      !rails70? && ::Rails::VERSION::MAJOR >= 7
+    end
+
+    def self.rails70_and_up?
+      ::Rails::VERSION::MAJOR >= 7
+    end
+
+    def self.rails70?
+      ::Rails.version.start_with? '7.0'
+    end
+  end
+end

--- a/test/dummy/config/initializers/prefixed_ids_test.rb
+++ b/test/dummy/config/initializers/prefixed_ids_test.rb
@@ -13,7 +13,7 @@ module PrefixedIds
     end
 
     def self.rails70?
-      ::Rails.version.start_with? '7.0'
+      ::Rails.version.start_with? "7.0"
     end
   end
 end

--- a/test/dummy/db/migrate/20240714120000_create_compound_primary_items.rb
+++ b/test/dummy/db/migrate/20240714120000_create_compound_primary_items.rb
@@ -1,0 +1,9 @@
+class CreateCompoundPrimaryItems < ActiveRecord::Migration[6.1]
+  def change
+    create_table :compound_primary_items, primary_key: [ :id, :user_id ] do |t|
+      t.integer :id
+      t.integer :user_id
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/migrate/20240714120000_create_compound_primary_items.rb
+++ b/test/dummy/db/migrate/20240714120000_create_compound_primary_items.rb
@@ -1,9 +1,11 @@
-class CreateCompoundPrimaryItems < ActiveRecord::Migration[6.1]
-  def change
-    create_table :compound_primary_items, primary_key: [:id, :user_id] do |t|
-      t.integer :id
-      t.integer :user_id
-      t.timestamps
+if PrefixedIds::Test.rails71_and_up?
+  class CreateCompoundPrimaryItems < ActiveRecord::Migration[6.1]
+    def change
+      create_table :compound_primary_items, primary_key: %i[id user_id] do |t|
+        t.integer :id
+        t.integer :user_id
+        t.timestamps
+      end
     end
   end
 end

--- a/test/dummy/db/migrate/20240714120000_create_compound_primary_items.rb
+++ b/test/dummy/db/migrate/20240714120000_create_compound_primary_items.rb
@@ -1,6 +1,6 @@
 class CreateCompoundPrimaryItems < ActiveRecord::Migration[6.1]
   def change
-    create_table :compound_primary_items, primary_key: [ :id, :user_id ] do |t|
+    create_table :compound_primary_items, primary_key: [:id, :user_id] do |t|
       t.integer :id
       t.integer :user_id
       t.timestamps

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_14_120000) do
+ActiveRecord::Schema.define(version: 2024_07_14_120000) do
   create_table "accounts", force: :cascade do |t|
     t.integer "user_id"
     t.datetime "created_at", null: false

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,8 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_03_211115) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_14_120000) do
   create_table "accounts", force: :cascade do |t|
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "compound_primary_items", primary_key: ["id", "user_id"], force: :cascade do |t|
+    t.integer "id"
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/test/fixtures/compound_primary_items.yml
+++ b/test/fixtures/compound_primary_items.yml
@@ -1,0 +1,19 @@
+one:
+  id: 1
+  user: one
+
+two:
+  id: 2
+  user: two
+
+three:
+  id: 3
+  user: three
+
+four:
+  id: 4
+  user: one
+
+five:
+  id: 5
+  user: one

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -229,17 +229,17 @@ class PrefixedIdsTest < ActiveSupport::TestCase
 
   test "compound primary - checks for a valid id upon decoding" do
     prefix = PrefixedIds::PrefixId.new(CompoundPrimaryItem, "compound")
-    hashid = Hashids.new(User.table_name, PrefixedIds.minimum_length, PrefixedIds.alphabet)
+    hashid = Hashids.new(CompoundPrimaryItem.table_name, PrefixedIds.minimum_length, PrefixedIds.alphabet)
 
     first = prefix.encode([1,1])
-    second = hashid.encode([2,1])
+    second = hashid.encode([1,1])
 
     assert_not_equal first.delete_prefix("compound" + PrefixedIds.delimiter), second
     assert_equal prefix.decode(second, fallback: true), second
 
     decoded = hashid.decode(second)
     assert_equal decoded.size, 2
-    assert_equal decoded, [2,1]
+    assert_equal decoded, [1,1]
   end
 
 end

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -223,7 +223,23 @@ class PrefixedIdsTest < ActiveSupport::TestCase
 
 
   test "compound primary - can get prefix ID from original ID" do
+    assert compound_primary_items(:one).id.kind_of?(Array)
     assert_equal compound_primary_items(:one).prefix_id, CompoundPrimaryItem.prefix_id(compound_primary_items(:one).id)
+  end
+
+  test "compound primary - checks for a valid id upon decoding" do
+    prefix = PrefixedIds::PrefixId.new(CompoundPrimaryItem, "compound")
+    hashid = Hashids.new(User.table_name, PrefixedIds.minimum_length, PrefixedIds.alphabet)
+
+    first = prefix.encode([1,1])
+    second = hashid.encode([2,1])
+
+    assert_not_equal first.delete_prefix("compound" + PrefixedIds.delimiter), second
+    assert_equal prefix.decode(second, fallback: true), second
+
+    decoded = hashid.decode(second)
+    assert_equal decoded.size, 2
+    assert_equal decoded, [2,1]
   end
 
 end

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -220,10 +220,8 @@ class PrefixedIdsTest < ActiveSupport::TestCase
     assert_nil Post.new.to_param
   end
 
-
-
   test "compound primary - can get prefix ID from original ID" do
-    assert compound_primary_items(:one).id.kind_of?(Array)
+    assert compound_primary_items(:one).id.is_a?(Array)
     assert_equal compound_primary_items(:one).prefix_id, CompoundPrimaryItem.prefix_id(compound_primary_items(:one).id)
   end
 
@@ -231,15 +229,14 @@ class PrefixedIdsTest < ActiveSupport::TestCase
     prefix = PrefixedIds::PrefixId.new(CompoundPrimaryItem, "compound")
     hashid = Hashids.new(CompoundPrimaryItem.table_name, PrefixedIds.minimum_length, PrefixedIds.alphabet)
 
-    first = prefix.encode([1,1])
-    second = hashid.encode([1,1])
+    first = prefix.encode([1, 1])
+    second = hashid.encode([1, 1])
 
     assert_not_equal first.delete_prefix("compound" + PrefixedIds.delimiter), second
     assert_equal prefix.decode(second, fallback: true), second
 
     decoded = hashid.decode(second)
     assert_equal decoded.size, 2
-    assert_equal decoded, [1,1]
+    assert_equal decoded, [1, 1]
   end
-
 end

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -220,23 +220,25 @@ class PrefixedIdsTest < ActiveSupport::TestCase
     assert_nil Post.new.to_param
   end
 
-  test "compound primary - can get prefix ID from original ID" do
-    assert compound_primary_items(:one).id.is_a?(Array)
-    assert_equal compound_primary_items(:one).prefix_id, CompoundPrimaryItem.prefix_id(compound_primary_items(:one).id)
-  end
+  if PrefixedIds::Test.rails71_and_up?
+    test "compound primary - can get prefix ID from original ID" do
+      assert compound_primary_items(:one).id.is_a?(Array)
+      assert_equal compound_primary_items(:one).prefix_id, CompoundPrimaryItem.prefix_id(compound_primary_items(:one).id)
+    end
 
-  test "compound primary - checks for a valid id upon decoding" do
-    prefix = PrefixedIds::PrefixId.new(CompoundPrimaryItem, "compound")
-    hashid = Hashids.new(CompoundPrimaryItem.table_name, PrefixedIds.minimum_length, PrefixedIds.alphabet)
+    test "compound primary - checks for a valid id upon decoding" do
+      prefix = PrefixedIds::PrefixId.new(CompoundPrimaryItem, "compound")
+      hashid = Hashids.new(CompoundPrimaryItem.table_name, PrefixedIds.minimum_length, PrefixedIds.alphabet)
 
-    first = prefix.encode([1, 1])
-    second = hashid.encode([1, 1])
+      first = prefix.encode([1, 1])
+      second = hashid.encode([1, 1])
 
-    assert_not_equal first.delete_prefix("compound" + PrefixedIds.delimiter), second
-    assert_equal prefix.decode(second, fallback: true), second
+      assert_not_equal first.delete_prefix("compound" + PrefixedIds.delimiter), second
+      assert_equal prefix.decode(second, fallback: true), second
 
-    decoded = hashid.decode(second)
-    assert_equal decoded.size, 2
-    assert_equal decoded, [1, 1]
+      decoded = hashid.decode(second)
+      assert_equal decoded.size, 2
+      assert_equal decoded, [1, 1]
+    end
   end
 end

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -219,4 +219,11 @@ class PrefixedIdsTest < ActiveSupport::TestCase
   test "calling to_param on non-persisted record" do
     assert_nil Post.new.to_param
   end
+
+
+
+  test "compound primary - can get prefix ID from original ID" do
+    assert_equal compound_primary_items(:one).prefix_id, CompoundPrimaryItem.prefix_id(compound_primary_items(:one).id)
+  end
+
 end


### PR DESCRIPTION
Rails 7.1 introduced support for compound or composite keys :

```ruby
class CreateProducts < ActiveRecord::Migration[7.1]
  def change
    create_table :products, primary_key: [:store_id, :sku] do |t|
      t.integer :store_id
      t.string :sku
      t.text :description
    end
  end
end
```

For such tables, model.id returns an array of the ids which make up the primary key.

This pull request adds support for this.  Previously, it would cause the hashids gem to error because it would be called with `@hashids.encode( token, [ 1, 2 ] )`.