### PR TITLE
Ensure that decode returns all parts of composite key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Unreleased
 
+* Ensure that decode returns all parts of composite key
+
+### 1.8.0
+
 * Add composite key support #70
 
 ### 1.7.1

--- a/lib/prefixed_ids/prefix_id.rb
+++ b/lib/prefixed_ids/prefix_id.rb
@@ -25,8 +25,8 @@ module PrefixedIds
       if !valid?(decoded_hashid)
         fallback_value
       else
-        _, id, *composite = decoded_hashid
-        composite.empty? ? id : composite
+        _, *ids = decoded_hashid
+        ids.size == 1 ? ids.first : ids
       end
     end
 

--- a/lib/prefixed_ids/prefix_id.rb
+++ b/lib/prefixed_ids/prefix_id.rb
@@ -26,7 +26,7 @@ module PrefixedIds
         fallback_value
       else
         _, *ids = decoded_hashid
-        ids.size == 1 ? ids.first : ids
+        (ids.size == 1) ? ids.first : ids
       end
     end
 

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -239,6 +239,9 @@ class PrefixedIdsTest < ActiveSupport::TestCase
       decoded = hashid.decode(second)
       assert_equal decoded.size, 2
       assert_equal decoded, [1, 1]
+
+      prefix_decoded = prefix.decode(first)
+      assert_equal prefix_decoded, [1, 1]
     end
   end
 end


### PR DESCRIPTION
This pull request addresses a bug in the decoding of composite keys. In the current implementation, when a model is defined with a composite primary key, the decoding process incorrectly strips out the first key component. This fix ensures that all components of the composite key are retained and correctly decoded.

For models with composite keys, such as the following example:

```ruby
class Product < ApplicationRecord
  has_prefix_id :prd
  self.primary_key = [:store_id, :sku]
end
```

The decode_prefix_id method fails to decode the composite key correctly. Specifically, when decoding the prefix_id for a Product instance, the resulting composite key array incorrectly omits the first key component.

Example to illustrate the issue:

```ruby
p = Product.create(store_id: 1, sku: 10)
composite = Product.decode_prefix_id(p.prefix_id)
```

Currently, the `composite` array is:

```ruby
[10]
```

However, the expected result should be:

```ruby
[1, 10]
```

This fix ensures that the decode_prefix_id method properly handles composite keys, preserving all components as intended.