### PR TITLE
Protect against fallback: false for exists?

### DIFF
--- a/lib/prefixed_ids.rb
+++ b/lib/prefixed_ids.rb
@@ -129,11 +129,16 @@ module PrefixedIds
     extend ActiveSupport::Concern
 
     class_methods do
-      def exists?(id)
-        if _prefix_id.present? && id.is_a?(String)
-          super(_prefix_id.decode(id))
+      def exists?(id_or_conditions)
+        return super if _prefix_id.blank?
+
+        if id_or_conditions.is_a?(Hash)
+          id = id_or_conditions.delete(:id)
+          super(id_or_conditions.merge(id: _prefix_id.decode(id, fallback: _prefix_id_fallback)))
+        else if id_or_conditions.is_a?(Array)
+          raise "exists? does not support arrays of conditions for prefixed ids"
         else
-          super
+          super(_prefix_id.decode(id_or_conditions, fallback: _prefix_id_fallback))
         end
       end
     end

--- a/lib/prefixed_ids.rb
+++ b/lib/prefixed_ids.rb
@@ -135,7 +135,7 @@ module PrefixedIds
         if id_or_conditions.is_a?(Hash)
           id = id_or_conditions.delete(:id)
           super(id_or_conditions.merge(id: _prefix_id.decode(id, fallback: _prefix_id_fallback)))
-        else if id_or_conditions.is_a?(Array)
+        elsif id_or_conditions.is_a?(Array)
           raise "exists? does not support arrays of conditions for prefixed ids"
         else
           super(_prefix_id.decode(id_or_conditions, fallback: _prefix_id_fallback))

--- a/lib/prefixed_ids.rb
+++ b/lib/prefixed_ids.rb
@@ -134,9 +134,18 @@ module PrefixedIds
 
         if id_or_conditions.is_a?(Hash)
           id = id_or_conditions.delete(:id)
-          super(id_or_conditions.merge(id: _prefix_id.decode(id, fallback: _prefix_id_fallback)))
+          if id.is_a?(Array)
+            prefix_ids = id.flatten.map do |i|
+              prefix_id = _prefix_id.decode(i, fallback: _prefix_id_fallback)
+              raise Error, "#{i} is not a valid prefix_id" if !_prefix_id_fallback && prefix_id.nil?
+              prefix_id
+            end
+            super(id_or_conditions.merge(id: prefix_ids))
+          else
+            super(id_or_conditions.merge(id: _prefix_id.decode(id, fallback: _prefix_id_fallback)))
+          end
         elsif id_or_conditions.is_a?(Array)
-          raise "exists? does not support arrays of conditions for prefixed ids"
+          raise Error, "exists? does not support arrays of conditions for prefixed ids"
         else
           super(_prefix_id.decode(id_or_conditions, fallback: _prefix_id_fallback))
         end

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -211,8 +211,11 @@ class PrefixedIdsTest < ActiveSupport::TestCase
 
   test "exists? works with conditions instead of ID" do
     account = accounts(:one)
+    account_two = accounts(:two)
 
     assert Account.exists?(id: account.id)
+    assert Account.exists?(id: [account.prefix_id, account_two.prefix_id])
+    assert Account.exists?(id: [account.prefix_id, account_two.prefix_id, 999_999])
   end
 
   test "exists? works correctly with multiple conditions" do

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -202,10 +202,24 @@ class PrefixedIdsTest < ActiveSupport::TestCase
     refute Post.exists?(post.prefix_id)
   end
 
+  test "disabled exists? when fallback false" do
+    team = teams(:one)
+
+    assert Team.exists?(team.prefix_id)
+    refute Team.exists?(team.id)
+  end
+
   test "exists? works with conditions instead of ID" do
     account = accounts(:one)
 
     assert Account.exists?(id: account.id)
+  end
+
+  test "exists? works correctly with multiple conditions" do
+    account = accounts(:one)
+
+    assert Account.exists?(id: account.id, user_id: account.user_id)
+    refute Account.exists?(id: account.id, user_id: account.user_id + 1)
   end
 
   test "calling find on an associated model without prefix id succeeds" do


### PR DESCRIPTION
I noticed that `exists?` with `fallback: false` is potentially still exposed to an enumeration vulnerability, which would allow attackers to determine things like the number of records in a table. E.g. If an attacker were to discover an endpoint that was backed simply by `Record.exists?` then this would allow them to pass in a non-prefixed id and potentially determine information like the number of records in a given table, even if `fallback` was set to false. I think this change makes the behavior a bit safer and more predictable, though I was unsure how to handle array find-conditions, so have treated those as unsupported for now.

Hopefully this is helpful. Let me know what you think :)