### PR TITLE
Ensure prefixes are unique

### DIFF
--- a/lib/prefixed_ids.rb
+++ b/lib/prefixed_ids.rb
@@ -28,6 +28,14 @@ module PrefixedIds
     [prefix, id]
   end
 
+  def self.register_prefix(prefix, model:)
+    if (existing_model = PrefixedIds.models[prefix]) && existing_model != model
+      raise Error, "Prefix #{prefix} already defined for model #{model}"
+    end
+
+    PrefixedIds.models[prefix] = model
+  end
+
   # Adds `has_prefix_id` method
   module Rails
     extend ActiveSupport::Concern
@@ -46,7 +54,7 @@ module PrefixedIds
         self._prefix_id_fallback = fallback
 
         # Register with PrefixedIds to support PrefixedIds#find
-        PrefixedIds.models[prefix.to_s] = self
+        PrefixedIds.register_prefix(prefix.to_s, model: self)
       end
     end
   end

--- a/test/prefixed_ids_test.rb
+++ b/test/prefixed_ids_test.rb
@@ -227,4 +227,28 @@ class PrefixedIdsTest < ActiveSupport::TestCase
       assert_equal prefix_decoded, [1, 1]
     end
   end
+
+  test "register_prefix adds the expected prefix and model" do
+    model = Class.new(ApplicationRecord) do
+      def self.name
+        "TestModel"
+      end
+    end
+
+    PrefixedIds.register_prefix("test_model", model: model)
+    assert_equal model, PrefixedIds.models["test_model"]
+  end
+
+  test "has_prefix_id raises when prefix was already used" do
+    assert PrefixedIds.models.key?("user")
+    assert_raises PrefixedIds::Error do
+      Class.new(ApplicationRecord) do
+        def self.name
+          "TestModel"
+        end
+
+        has_prefix_id :user
+      end
+    end
+  end
 end


### PR DESCRIPTION
When two or more models are defined with the same prefix, `PrefixedIds.find` will load the model for whichever one was defined last, and could lead to loading an unexpected model for a given prefixed id.

For apps with lots of models it’s quite easy to add the same prefix on two or more models by mistake. It’s also not obvious how to access or list the prefixes already in use, so I think it makes sense for the gem to protect against this.

This PR adds a check when calling `has_prefix_id` and raises `PrefixedIds::Error` if the same prefix was already defined for a different model.