### PR TITLE
CHANGED: Updated hash generation to use Sqids rather than HashIds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* [Breaking] Switch to [sqids](https://sqids.org/ruby) for hash ID generation. - @tarellel
+
 * [Breaking] Remove `exists?` override.
 
 To continue using `exists?`, you can decode the ID first:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     prefixed_ids (1.8.1)
-      hashids (>= 1.0.0, < 2.0.0)
       rails (>= 6.0.0)
+      sqids (>= 0.2.2, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -96,7 +96,6 @@ GEM
     erubi (1.13.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    hashids (1.0.6)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
@@ -203,6 +202,7 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.3.2)
+    sqids (0.2.2)
     sqlite3 (2.3.0)
       mini_portile2 (~> 2.8.0)
     sqlite3 (2.3.0-x86_64-darwin)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ user_12345abcd
 acct_23lksjdg3
 ```
 
-This gem works by hashing the record's original `:id` attribute using [`Hashids`](https://hashids.org/ruby/), which transforms numbers like 347 into a string like yr8. It uses the table's name and an optional additional salt to hash values, returning a string like `tablename_hashedvalue`.
+This gem works by hashing the record's original `:id` attribute using [`Sqids`](https://sqids.org/ruby/), which transforms numbers like 347 into a string like yr8. It uses the table's name and an optional additional salt to hash values, returning a string like `tablename_hashedvalue`.
 
 Inspired by [Stripe's prefixed IDs](https://stripe.com/docs/api) in their API.
 

--- a/gemfiles/rails_6.gemfile.lock
+++ b/gemfiles/rails_6.gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: ..
   specs:
     prefixed_ids (1.8.1)
-      hashids (>= 1.0.0, < 2.0.0)
       rails (>= 6.0.0)
+      sqids (>= 0.2.2,< 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -75,7 +75,6 @@ GEM
     erubi (1.13.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
-    hashids (1.0.6)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     json (2.8.2)
@@ -173,6 +172,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqids (0.2.2)
     sqlite3 (1.7.3)
       mini_portile2 (~> 2.8.0)
     sqlite3 (1.7.3-x86_64-darwin)

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: ..
   specs:
     prefixed_ids (1.8.1)
-      hashids (>= 1.0.0, < 2.0.0)
       rails (>= 6.0.0)
+      sqids (>= 0.2.2,< 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -79,7 +79,6 @@ GEM
     erubi (1.13.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    hashids (1.0.6)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     json (2.8.2)
@@ -177,6 +176,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    sqids (0.2.2)
     sqlite3 (1.7.3)
       mini_portile2 (~> 2.8.0)
     sqlite3 (1.7.3-x86_64-darwin)

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: ..
   specs:
     prefixed_ids (1.8.1)
-      hashids (>= 1.0.0, < 2.0.0)
       rails (>= 6.0.0)
+      sqids (>= 0.2.2,< 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -85,7 +85,6 @@ GEM
     erubi (1.13.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    hashids (1.0.6)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     json (2.8.2)
@@ -174,6 +173,7 @@ GEM
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
+    sqids (0.2.2)
     sqlite3 (1.7.3-arm64-darwin)
     sqlite3 (1.7.3-x86_64-darwin)
     sqlite3 (1.7.3-x86_64-linux)

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: ..
   specs:
     prefixed_ids (1.8.1)
-      hashids (>= 1.0.0, < 2.0.0)
       rails (>= 6.0.0)
+      sqids (>= 0.2.2,< 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -102,7 +102,6 @@ GEM
     erubi (1.13.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    hashids (1.0.6)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
@@ -208,6 +207,7 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.3.2)
+    sqids (0.2.2)
     sqlite3 (1.7.3-arm64-darwin)
     sqlite3 (1.7.3-x86_64-darwin)
     sqlite3 (1.7.3-x86_64-linux)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: ..
   specs:
     prefixed_ids (1.8.1)
-      hashids (>= 1.0.0, < 2.0.0)
       rails (>= 6.0.0)
+      sqids (>= 0.2.2, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -96,7 +96,6 @@ GEM
     erubi (1.13.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    hashids (1.0.6)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
@@ -207,6 +206,7 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.3.2)
+    sqids (0.2.2)
     sqlite3 (2.3.0-aarch64-linux-gnu)
     sqlite3 (2.3.0-aarch64-linux-musl)
     sqlite3 (2.3.0-arm-linux-gnu)

--- a/gemfiles/rails_main.gemfile.lock
+++ b/gemfiles/rails_main.gemfile.lock
@@ -101,8 +101,8 @@ PATH
   remote: ..
   specs:
     prefixed_ids (1.8.1)
-      hashids (>= 1.0.0, < 2.0.0)
       rails (>= 6.0.0)
+      sqids (>= 0.2.2, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -124,7 +124,6 @@ GEM
     erubi (1.13.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    hashids (1.0.6)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
@@ -209,6 +208,7 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.3.2)
+    sqids (0.2.2)
     sqlite3 (2.3.0)
       mini_portile2 (~> 2.8.0)
     sqlite3 (2.3.0-x86_64-darwin)

--- a/lib/prefixed_ids.rb
+++ b/lib/prefixed_ids.rb
@@ -1,7 +1,7 @@
 require "prefixed_ids/version"
 require "prefixed_ids/engine"
 
-require "hashids"
+require "sqids"
 
 module PrefixedIds
   class Error < StandardError; end

--- a/lib/prefixed_ids/prefix_id.rb
+++ b/lib/prefixed_ids/prefix_id.rb
@@ -7,7 +7,10 @@ module PrefixedIds
     def initialize(model, prefix, salt: PrefixedIds.salt, minimum_length: PrefixedIds.minimum_length, alphabet: PrefixedIds.alphabet, delimiter: PrefixedIds.delimiter, **options)
       @prefix = prefix.to_s
       @delimiter = delimiter.to_s
-      @hashids = Hashids.new("#{model.table_name}#{salt}", minimum_length, alphabet)
+      @salt = salt.to_s
+      salt_bytes = salt.bytes
+      @salted_alphabet = alphabet.chars.shuffle(random: Random.new(salt_bytes.sum)).join
+      @hashids = Sqids.new(min_length: minimum_length, alphabet: @salted_alphabet)
     end
 
     def encode(id)

--- a/prefixed_ids.gemspec
+++ b/prefixed_ids.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency "rails", ">= 6.0.0"
-  spec.add_dependency "hashids", ">= 1.0.0", "< 2.0.0"
+  spec.add_dependency "sqids", ">= 0.2.2", "< 1.0.0"
 end


### PR DESCRIPTION
**Summary:**

Convert prefixed_ids from using hashids to use [Sqids](https://sqids.org/ruby) as its new hashing library.

**Context:**

https://github.com/peterhellberg/hashids.rb

> Hashids has been rebranded to 🦑 Sqids, and there is a Ruby implementation of it that I suggest you use instead of Hashids.rb